### PR TITLE
fix: Sympy log parsing no longer drops the last result

### DIFF
--- a/swebench/harness/log_parsers.py
+++ b/swebench/harness/log_parsers.py
@@ -201,7 +201,7 @@ def parse_log_sympy(log: str) -> dict[str, str]:
         test_case = f"{match[1]}.py:{match[2]}"
         test_status_map[test_case] = TestStatus.FAILED.value
     for line in log.split("\n"):
-        line = line.strip()
+        line = re.sub(r"\[[^]]*\]$", "", line, flags=re.MULTILINE).strip()
         if line.startswith("test_"):
             if line.endswith(" E"):
                 test = line.split()[0]

--- a/tests/test_log_parsers.py
+++ b/tests/test_log_parsers.py
@@ -1,0 +1,24 @@
+import unittest
+from swebench.harness.log_parsers import parse_log_sympy
+from swebench.harness.constants import TestStatus
+
+
+class TestParseLogSympy(unittest.TestCase):
+    def test_parse_log_sympy(self):
+        log = """
+        test_printing_cyclic ok
+        test_printing_non_cyclic ok                                                 [OK]
+        test_failure_case F
+        test_error_case E
+        """
+        expected_output = {
+            "test_printing_cyclic": TestStatus.PASSED.value,
+            "test_printing_non_cyclic": TestStatus.PASSED.value,
+            "test_failure_case": TestStatus.FAILED.value,
+            "test_error_case": TestStatus.ERROR.value,
+        }
+        self.assertEqual(parse_log_sympy(log), expected_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Sympy log parsing checks each line to see if it ends in E/F/ok when parsing log output. However, at the end of a run, the string `[OK]` or similar (I'm guessing, if something failed) would be written to the last line. This would cause the last test case not to be parsed.

This change drops any text at the end of the line within square brackets before checking for test status. Examples are provided below.

```
============================= test process starts ==============================

sympy/combinatorics/tests/test_permutations.py[9]
test_Permutation ok
test_josephus ok
test_ranking ok
test_mul ok
test_args ok
test_Cycle ok
test_from_sequence ok
test_printing_cyclic ok
test_printing_non_cyclic ok                                                 [OK]

================== tests finished: 9 passed, in 0.14 seconds ===================
```

```
============================= test process starts ==============================

sympy/combinatorics/tests/test_cycle_permutations.py[1]
test_non_disjoint_cycles ok                                                 [OK]

================== tests finished: 1 passed, in 0.09 seconds ===================
```
