### PR TITLE
fix: Don't error out on unicode error in docker exec stream

### DIFF
--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -173,7 +173,7 @@ def cleanup_container(client, container, logger):
         )
 
 
-def exec_run_with_timeout(container, cmd, timeout: int|None=60):
+def exec_run_with_timeout(container: Container, cmd, timeout: int | None = 60):
     """
     Run a command in a container with a timeout.
 
@@ -195,7 +195,7 @@ def exec_run_with_timeout(container, cmd, timeout: int|None=60):
             exec_id = container.client.api.exec_create(container.id, cmd)["Id"]
             exec_stream = container.client.api.exec_start(exec_id, stream=True)
             for chunk in exec_stream:
-                exec_result += chunk.decode()
+                exec_result += chunk.decode("utf-8", errors="backslashreplace")
         except Exception as e:
             exception = e
 


### PR DESCRIPTION
The code uses `bytearray.decode()` to decode exec stream from a container; this method by default throws when it can't decode UTF-8 from the input. This change makes it output `\xhh` escape sequences when it cannot decode something instead.

Fixes #41 